### PR TITLE
support asserting JSON types other than objects (fixes #16)

### DIFF
--- a/assert/json.go
+++ b/assert/json.go
@@ -4,21 +4,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 )
 
-func unmarshal(buf []byte) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
+func unmarshal(buf []byte) (interface{}, error) {
+	var data interface{}
 	if err := json.Unmarshal(buf, &data); err != nil {
 		return data, fmt.Errorf("failed to Unmarshal: %s", err)
 	}
 	return data, nil
 }
 
-func unmarshalBody(res *http.Response) (map[string]interface{}, error) {
+func unmarshalBody(res *http.Response) (interface{}, error) {
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
@@ -29,7 +28,7 @@ func unmarshalBody(res *http.Response) (map[string]interface{}, error) {
 	return unmarshal(body)
 }
 
-func marshal(data map[string]interface{}) ([]byte, error) {
+func marshal(data interface{}) ([]byte, error) {
 	return json.Marshal(data)
 }
 
@@ -44,53 +43,48 @@ func readBodyJSON(res *http.Response) ([]byte, error) {
 	return body, err
 }
 
-func compare(body map[string]interface{}, data interface{}) error {
+func compare(body interface{}, data interface{}) error {
 	var err error
-	var match map[string]interface{}
+	var matchBytes []byte
 
-	// Infer and cast string input
-	if jsonStr, ok := data.(string); ok {
-		data = []byte(jsonStr)
+	// taking pointer to json.RawMessage due to regression in go 1.7 (https://github.com/golang/go/issues/14493)
+	var matchData interface{}
+	switch data := data.(type) {
+	case json.Marshaler:
+		matchData = data
+	case string:
+		v := json.RawMessage([]byte(data))
+		matchData = &v
+	case []byte:
+		v := json.RawMessage(data)
+		matchData = &v
+	default:
+		matchData = data
 	}
+	matchBytes, err = marshal(matchData)
 
-	// Infer and cast string input
-	if reader, ok := data.(io.Reader); ok {
-		data, err = ioutil.ReadAll(reader)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Infer and cast input as map
-	if fields, ok := data.(map[string]interface{}); ok {
-		data, err = marshal(fields)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Infer and cast bytes input
-	buf, ok := data.([]byte)
-	if ok {
-		match, err = unmarshal(buf)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	// Assert via string
-	bodyBuf, err := marshal(body)
-	if err != nil {
-		return err
-	}
-	matchBuf, err := marshal(match)
+	bodyBytes, err := marshal(body)
 	if err != nil {
 		return err
 	}
 
-	// Compare by byte sequences
-	if !reflect.DeepEqual(bodyBuf, matchBuf) {
-		return fmt.Errorf("failed due to JSON mismatch:\n\thave: %#v\n\twant: %#v", string(bodyBuf), string(matchBuf))
+	bodyValue, err := unmarshal(bodyBytes)
+	if err != nil {
+		return err
+	}
+	matchValue, err := unmarshal(matchBytes)
+	if err != nil {
+		return err
+	}
+
+	// Compare values so order of keys in maps does not influence the result
+	if !reflect.DeepEqual(bodyValue, matchValue) {
+		return fmt.Errorf("failed due to JSON mismatch:\n\thave: %#v\n\twant: %#v", string(bodyBytes), string(matchBytes))
 	}
 
 	return nil

--- a/assert/json_test.go
+++ b/assert/json_test.go
@@ -25,12 +25,77 @@ func TestJSONBuffer(t *testing.T) {
 	st.Expect(t, JSON(match)(res, nil), nil)
 }
 
-func TestJSONMap(t *testing.T) {
-	body := ioutil.NopCloser(bytes.NewBufferString(`{"foo": [{"bar":"baz"}]}`))
-	res := &http.Response{Body: body}
-	list := []items{{"bar": "baz"}}
-	match := map[string]interface{}{"foo": list}
-	st.Expect(t, JSON(match)(res, nil), nil)
+type literalJSON string
+
+func (v literalJSON) MarshalJSON() ([]byte, error) {
+	return []byte(v), nil
+}
+
+func TestJSON(t *testing.T) {
+	type genMap map[string]interface{}
+	type strMap map[string]string
+	testcases := []struct {
+		name  string
+		body  string
+		match interface{}
+	}{
+		{
+			name:  "generic map",
+			body:  `{"foo": [{"bar":"baz"}]}`,
+			match: genMap{"foo": []items{{"bar": "baz"}}},
+		},
+		{
+			name:  "string to sring map",
+			body:  `{"foo": "bar"}`,
+			match: strMap{"foo": "bar"},
+		},
+		{
+			name:  "array",
+			body:  `["foo", 1.0]`,
+			match: []interface{}{"foo", 1.0},
+		},
+		{
+			name:  "custom type with json marshaller",
+			body:  `"foo"`,
+			match: literalJSON(`"foo"`),
+		},
+		{
+			name: "keys order in map does not matter",
+			body: `
+        {
+          "args": {},
+          "headers": {
+          	"Accept-Encoding": "gzip",
+          	"Connection": "close",
+          	"Foo": "Bar",
+          	"Host": "httpbin.org",
+          	"User-Agent": "baloo/2.0.0"
+          },
+          "origin": "0.0.0.0",
+          "url": "http://httpbin.org/get"
+        }`,
+			match: literalJSON(`
+				{
+          "args": {},
+          "headers": {
+          	"Connection": "close",
+          	"Accept-Encoding": "gzip",
+          	"Foo": "Bar",
+          	"Host": "httpbin.org",
+          	"User-Agent": "baloo/2.0.0"
+          },
+          "origin": "0.0.0.0",
+          "url": "http://httpbin.org/get"
+        }`),
+		},
+	}
+	for i, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := ioutil.NopCloser(bytes.NewBufferString(tc.body))
+			res := &http.Response{Body: body}
+			st.Expect(t, JSON(tc.match)(res, nil), nil, i)
+		})
+	}
 }
 
 func TestCompare(t *testing.T) {


### PR DESCRIPTION
The JSON matching is is adjusted to compared marshalled values instead of bytes because the order of JSON object keys is non deterministic and therefore can cause comparisons to fail.