### PR TITLE
Take an interface instead of *testing.T

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -3,7 +3,6 @@ package baloo
 import (
 	"fmt"
 	"net/http"
-	"testing"
 
 	"gopkg.in/h2non/baloo.v3/assert"
 )
@@ -24,10 +23,15 @@ func FlushAssertFuncs() {
 	Assertions = make(map[string]assert.Func)
 }
 
+// TestingT implements part of the same interface as testing.T
+type TestingT interface {
+	Error(args ...interface{})
+}
+
 // Expect represents the HTTP expectation suite who is
 // able to define multiple assertion functions to match the response.
 type Expect struct {
-	test       *testing.T
+	test       TestingT
 	request    *Request
 	assertions []assert.Func
 }
@@ -40,7 +44,7 @@ func NewExpect(req *Request) *Expect {
 // BindTest binds the Go testing instance to the current suite.
 // In the future multiple testing interfaces can
 // be supported via adapters.
-func (e *Expect) BindTest(t *testing.T) *Expect {
+func (e *Expect) BindTest(t TestingT) *Expect {
 	e.test = t
 	return e
 }

--- a/request.go
+++ b/request.go
@@ -3,7 +3,6 @@ package baloo
 import (
 	"io"
 	"net/http"
-	"testing"
 
 	"gopkg.in/h2non/gentleman.v2"
 	"gopkg.in/h2non/gentleman.v2/context"
@@ -213,7 +212,7 @@ func (r *Request) Send() (*gentleman.Response, error) {
 }
 
 // Expect creates and returns the request test expectation suite.
-func (r *Request) Expect(t *testing.T) *Expect {
+func (r *Request) Expect(t TestingT) *Expect {
 	if r.tested {
 		t.Error("[baloo] request already tested")
 		return nil
@@ -223,7 +222,7 @@ func (r *Request) Expect(t *testing.T) *Expect {
 }
 
 // Assert is an alias to .Expect().
-func (r *Request) Assert(t *testing.T) *Expect {
+func (r *Request) Assert(t TestingT) *Expect {
 	return r.Expect(t)
 }
 


### PR DESCRIPTION
This change would make baloo interoperable with alternative test runners that implement their own T-like testing objects.