### PR TITLE
Bubble Up regexp Error For BodyMatchString

### DIFF
--- a/assert/body.go
+++ b/assert/body.go
@@ -27,8 +27,8 @@ func BodyMatchString(pattern string) Func {
 		if err != nil {
 			return err
 		}
-		if match, _ := regexp.MatchString(pattern, string(body)); !match {
-			return fmt.Errorf("body mismatch: pattern not found '%s'", pattern)
+		if match, err := regexp.MatchString(pattern, string(body)); !match {
+			return fmt.Errorf("body mismatch: '%s'", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
This should make fixing regex pattern issues easier... to bubble up an error like this:

https://play.golang.org/p/dubZiQ-HCN0