### PR TITLE
Fix wrong file in logged message when failure occurs

### DIFF
--- a/assert/status.go
+++ b/assert/status.go
@@ -39,7 +39,7 @@ func StatusRedirect() Func {
 func StatusEqual(code int) Func {
 	return func(res *http.Response, req *http.Request) error {
 		if res.StatusCode != code {
-			return fmt.Errorf("Unexpected status code for: %s %s => %d != %d", req.Method, req.Url.String(), res.StatusCode, code)
+			return fmt.Errorf("Unexpected status code for: %s %s => %d != %d", req.Method, req.URL.String(), res.StatusCode, code)
 		}
 		return nil
 	}


### PR DESCRIPTION
This fixes #28 
However I did not find a way to completely customize the logged message because the `testing` package does not allow such thing, (see https://github.com/golang/go/issues/37708)

The printed message shows now where the error occurs in the calling code, however `expect.go:213:` will still appear as a prefix to the error message, for example:

`expect.go:213: http_test.go:12: Unexpected status code: 400 != 11`